### PR TITLE
fix: Hello button message was printing <@@user> instead of @user

### DIFF
--- a/src/commands/slash + button.ts
+++ b/src/commands/slash + button.ts
@@ -28,7 +28,7 @@ class buttonExample {
     const row = new MessageActionRow().addComponents(helloBtn);
 
     interaction.editReply({
-      content: `<@${user}>, Say hello to bot`,
+      content: `${user}, Say hello to bot`,
       components: [row],
     });
   }


### PR DESCRIPTION
when you do /hello-btn @user the bot was not writting the mention correctly, if the command receive a @user, you have to do ${user} instead of <@${user}> 